### PR TITLE
Rebuild: v0.17.6 b1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,0 @@
-aggregate_check: false
-upload_channels:
-  - services
-  - sfe1ed40
-channels:
-  - services
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7fea8b4e47ac38bd4eaad8a76e38a6916419df930ad1c615a6b43feb427672c4
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - databricks=databricks_cli.cli:cli
     - dbfs=databricks_cli.dbfs.cli:dbfs_group


### PR DESCRIPTION
`abs.yaml` was mistakenly left in #3 :
- bump build number 
- remove abs.yaml